### PR TITLE
Support ${workspaceFolder} for buildifier path

### DIFF
--- a/src/buildifier/buildifier.ts
+++ b/src/buildifier/buildifier.ts
@@ -164,6 +164,9 @@ export function getDefaultBuildifierExecutablePath(): string {
   // just use "buildifier" as the default and get it from the system PATH.
   const bazelConfig = vscode.workspace.getConfiguration("bazel");
   const buildifierExecutable = bazelConfig.get<string>("buildifierExecutable");
+  if (vscode.workspace.rootPath !== undefined) {
+    buildifierExecutable.replace("${workspaceFolder}", vscode.workspace.rootPath);
+  }
   if (buildifierExecutable.length === 0) {
     return "buildifier";
   }


### PR DESCRIPTION
Allows for settings the buildifier path in a a vscode workspace file. Useful when you have a hermetic buildifier in your repo and want to refer to it relative to the vscode workspace root.